### PR TITLE
IDEM-1759 : Redirect url for saml sso was getting encoded twice.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,29 +1,29 @@
 {
-  "version": "0.2.0",
-  "configurations": [
-    {
-      "name": "Debug Jest Tests",
-      "type": "node",
-      "request": "launch",
-      "runtimeArgs": [
-        "--inspect-brk",
-        "${workspaceRoot}/node_modules/.bin/jest",
-        "--runTestsByPath",
-        "${relativeFile}",
-        "--runInBand"
-      ],
-      "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
-      "port": 9229,
-      "skipFiles": ["<node_internals>/**"]
-    },
-    {
-      "name": "Electron: Main",
-      "type": "node",
-      "request": "launch",
-      "protocol": "inspector",
-      "runtimeExecutable": "yarn",
-      "runtimeArgs": ["start-electron --inspect=5858 --remote-debugging-port=9223"]
-    }
-  ]
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Debug Jest Tests",
+        "type": "node",
+        "request": "launch",
+        "runtimeArgs": [
+          "--inspect-brk",
+          "${workspaceRoot}/node_modules/.bin/jest",
+          "--runTestsByPath",
+          "${relativeFile}",
+          "--runInBand"
+        ],
+        "console": "integratedTerminal",
+        "internalConsoleOptions": "neverOpen",
+        "port": 9229,
+        "skipFiles": ["<node_internals>/**"]
+      },
+      {
+        "name": "Electron: Main",
+        "type": "node",
+        "request": "launch",
+        "protocol": "inspector",
+        "runtimeExecutable": "yarn",
+        "runtimeArgs": ["start-electron --inspect=5858 --remote-debugging-port=9223"]
+      }
+    ]
 }

--- a/packages/teleport/src/Login/ssoLogin.ts
+++ b/packages/teleport/src/Login/ssoLogin.ts
@@ -3,19 +3,31 @@ import history from 'teleport/services/history';
 import cfg from 'teleport/config';
 
 export default function ssoLogin() {
-    console.log("sso login start")
+    console.log("SSO login start")
     const authProviders = cfg.getAuthProviders();
     let provider = authProviders[0]
     const appStartRoute = getEntryRoute();
+    console.log("Redirect URL after sso login:" + appStartRoute)
     const ssoUri = cfg.getSsoUrl(provider.url, provider.name, appStartRoute);
-    console.log("sso login url:" + ssoUri)
+    console.log("SSO login url:" + ssoUri)
     history.push(ssoUri, true);
 }
 
+export function redirectToExternalIdentityProvider() {
+    if ( cfg.baseUrl.endsWith('.idemeum.com') || cfg.baseUrl.endsWith('.idemeumlab.com')) {
+        const loginUrl = cfg.baseUrl.replace('.remote.', '.')
+        console.log("Redirecting to external identity provider:" + loginUrl)
+        window.location.href = loginUrl;
+    }
+    else {
+        window.location.href = cfg.baseUrl;
+    }
+}
+
 function getEntryRoute() {
-    const { search, pathname } = history.original().location;
-    const knownRoute = history.ensureKnownRoute(pathname);
+    var redirectUrl = new URL(decodeURIComponent(window.location.href))
+    const knownRoute = history.ensureKnownRoute(redirectUrl.pathname);
     const knownRedirect = history.ensureBaseUrl(knownRoute);
-    const query = search ? search : '';
+    const query = redirectUrl.search ? redirectUrl.search : '';
     return knownRedirect + query
 }

--- a/packages/teleport/src/services/websession/websession.ts
+++ b/packages/teleport/src/services/websession/websession.ts
@@ -16,12 +16,11 @@ limitations under the License.
 
 import Logger from 'shared/libs/logger';
 import cfg from 'teleport/config';
-import history from 'teleport/services/history';
 import api from 'teleport/services/api';
 import localStorage, { KeysEnum } from 'teleport/services/localStorage';
 import makeBearerToken from './makeBearerToken';
 import { RenewSessionRequest } from './types';
-import ssoLogin from 'teleport/Login/ssoLogin';
+import { redirectToExternalIdentityProvider } from 'teleport/Login/ssoLogin';
 
 
 // Time to determine when to renew session which is
@@ -35,7 +34,7 @@ let sesstionCheckerTimerId = null;
 const session = {
   logout() {
     api.delete(cfg.api.sessionPath).finally(() => {
-      ssoLogin()
+      redirectToExternalIdentityProvider()
     });
 
     this.clear();


### PR DESCRIPTION
- Read the redirect url and pass it to saml sso endpoint
- logout redirects to external idp login page