### PR TITLE
IDEM-1892: Part1 rename the login page to /login/$system

### DIFF
--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -84,7 +84,7 @@ const cfg = {
     consoleConnect: '/web/cluster/:clusterId/console/node/:serverId/:login',
     consoleSession: '/web/cluster/:clusterId/console/session/:sid',
     player: '/web/cluster/:clusterId/session/:sid', // ?recordingType=ssh|desktop|k8s&durationMs=1234
-    login: '/web/login',
+    login: '/web/$system',
     loginSuccess: '/web/msg/info/login_success',
     loginErrorLegacy: '/web/msg/error/login_failed',
     loginError: '/web/msg/error/login',


### PR DESCRIPTION
- We will disable the /web/login in teleport backend
- For admin backdoor entry we will use /web/$system path