### PR TITLE
IDEM-2040: Fix the redirect url for idemeum

### DIFF
--- a/packages/design/src/idemeum/Card.tsx
+++ b/packages/design/src/idemeum/Card.tsx
@@ -63,7 +63,7 @@ export default function Card({ message, redirectUrl, showIcon }: { message?: str
                 {redirectUrl ?
                     <Flex justifyContent="center" alignItems="center">
                         <Text style={{ color: 'black', marginTop: 10, fontSize: 15, fontWeight: 500, fontFamily: 'Red Hat Display' }}>
-                            Click <a style={{ color: '#007bff' }} href={window.location.origin.replace(".remote.","")}>here</a> to Login Again
+                            Click <a style={{ color: '#007bff' }} href={window.location.origin.replace(".remote.", ".")}>here</a> to Login Again
                         </Text>
                     </Flex> : null}
             </Box>


### PR DESCRIPTION
- Current logic to replace ".remote" with "" has a bug where it should be replacing the ".remote." with "." so that example.remote.idemeumlab.com" becomes example.idemeumlab.com